### PR TITLE
Rewrite of README.md and addition of other files

### DIFF
--- a/CODE_OF_CONDUCT.MD
+++ b/CODE_OF_CONDUCT.MD
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at codebuddiesdotorg@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+## Contribution instructions
+
+1. Fork this repo.
+2. `git remote add upstream https://github.com/codebuddies/frontend.git` and
+3. Run `npm install` and `npm start`. You should see the application starting up on `localhost:3000`!
+4. Fork and clone the [backend](https://codebuddies.org/codebuddies/backend), a Django application using Django REST Framework, to launch a development version of the API (`localhost:8000`)
+
+We also have a "fake" API set up in the db.json file, which our React components in localhost:3000/resources pull from.
+
+5. Find an issue and leave a comment if you'd like to work on it!
+6. Join the `#codebuddies-meta` and `#cb-v3-frontend` channels on [Slack](https://codebuddies.org/slack) (optional, but many project updates will be there). Some of the folks working on this project _may_ be willing to pair program on issues, and this channel is a good space to ask.
+
+## Storybook (optional)
+
+We are utilizing Storybook for showing components in an isolated way.
+You can create your own storybook from components that you create. The files need to have the `.stories.js` ending to be picked up by storybook.
+
+To run the storybook application, use the following command
+
+```
+npm run storybook
+```
+
+## Design
+
+1/ Crowdsourced brainstorm document of problems we want to solve: https://pad.riseup.net/p/BecKdThFsevRmmG_tqFa-keep
+
+2/ The final designs and product specs are still being figured out, but we've put everything into [figma](https://www.figma.com/file/wXMeX9xgYTcVKNJ1XT9ZQ5/cbv3poc?node-id=0%3A1).
+
+### Using Material UI
+
+We're using Material-UI's [Hooks API](https://material-ui.com/styles/basics/#hook-api), which means you can (and should) use [Material UI's components](https://material-ui.com/getting-started/supported-components/) as a starting point, and extend them as needed using `makeStyles` and `useStyles`.
+
+See the [Nav component](https://github.com/codebuddies/react-concept/blob/master/src/components/Nav/index.js) for an example that uses several Material-UI components, and the `makeStyles` hook to customize the rest.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,57 @@
-# react-concept
+## **Overview of Codebuddies**
 
-Frontend proof of concept of CodeBuddies v3 using React.
+### **What is CodeBuddies?**
 
-## Contribution instructions
+[CodeBuddies](https://codebuddies.org/) is a remote-first community of independent code learners who enjoy sharing knowledge and helping each other learn faster via discussions and pairing. It is free and open-sourced, and supported by open source contributors and financial backers on our [Open Collective](https://opencollective.com/codebuddies).
 
-1. Fork this repo.
-2. Find an issue and leave a comment if you're interested in it.
-3. Run `npm install` and `npm start`
+### CodeBuddies website Version 3 (CBV3)
 
-We have a "fake" API set up in the db.json file, which our React components pull from.
+We are building out a new platform (CBV3) to replace an [older MeteorJS project](http://github.com/codebuddies/codebuddies) which currently runs the [codebuddies.org site](<(https://codebuddies.org/)>).
 
-## Storybook
+## Role of the front-end
 
-We are utilizing Storybook for showing components in an isolated way.
-You can create your own storybook from components that you create. The files need to have the `.stories.js` ending to be picked up by storybook.
+The front-end is a React app that aims to let users at a bare minimum:
 
-To run the storybook application, use the following command
+- submit resources
+- meet remotely on Zoom to pair, show off a project, hack on an open source project, or study together.
 
-```
-npm run storybook
-```
+## **Helpful links**
 
-## Design
+1/ CBV3's [backend](https://github.com/codebuddies/backend) API is built using Django and Django REST Framework.
 
-View proof of concept designs over on the [official V3 repo](https://github.com/codebuddies/v3/issues?q=is%3Aissue+is%3Aopen+label%3Adesign) labeled "design". Note that the designs are only meant to serve as a guide and the output does not need to be pixel perfect. Instead, use [Material-UI](https://material-ui.com/) components as a starting point and extend as needed.
+2/ Some [Google doc technical notes](https://docs.google.com/document/u/1/d/1YuVO-v0n73ogoFIwpwJgI1Bkso8sP2mg5zqbX9FB3lU/edit#heading=h.rw88rxuk12cp) from hangouts/pairing sessions
 
-The PoC for the frontend will revolve around querying and posting the Resource model based on the defined [API spec](https://app.swaggerhub.com/apis-docs/billglover/CodeBuddies/0.0.1).
+3/ We have a technical decision log [here](https://github.com/codebuddies/frontend/wiki/Technical-decision-log) and a group blog experiment [here](https://github.com/codebuddies/frontend/issues/98)
 
-### Using Material UI
+4/ Crowdsourced [brainstorm of problems we want to solve](https://pad.riseup.net/p/BecKdThFsevRmmG_tqFa-keep) for our community with this platform
 
-We're using Material-UI's [Hooks API](https://material-ui.com/styles/basics/#hook-api), which means you can (and should) use [Material UI's components](https://material-ui.com/getting-started/supported-components/) as a starting point, and extend them as needed using `makeStyles` and `useStyles`.
+## **Technologies we're using**
 
-See the [Nav component](https://github.com/codebuddies/react-concept/blob/master/src/components/Nav/index.js) for an example that uses several Material-UI components, and the `makeStyles` hook to customize the rest.
+- [React (hooks)](https://reactjs.org/docs/hooks-intro.html)
+- [Storybook](https://storybook.js.org/)
+- [React testing library](https://github.com/testing-library/react-testing-library)
+- [Django REST Framework](https://github.com/encode/django-rest-framework) (for the [backend](https://github.com/codebuddies/backend) API)
 
-## Pages
+**Application Deployment**
 
-**Index**
+Special thanks to Netlify for sponsoring our front-end hosting!
 
-The main landing page will have a small copy as well as a Sign Up and Sign in form (see You can find these pages at [Figma](https://www.figma.com/file/wXMeX9xgYTcVKNJ1XT9ZQ5/cbv3poc?node-id=0%3A1) for reference).
+## **How do I contribute to this codebase?**
 
-After authenticating, the root page should be defined as the **Resources Index** page.
+Follow the [CONTRIBUTING.md](CONTRIBUTING.md) instructions!
 
-**Resources**
+## **Have Questions about CBV3?**
 
-The Resources page displays a search form. From this page, a user can search for a resource and add a new resource. After searching for a resource, it should populate with the search results. Clicking on `Add a Resource` should open a modal with a form to add a Resource. On success, it should give a message that a resource was added successfully, or if there are errors, display error messages in an [flash message](https://material-ui.com/components/snackbars/).
+Check out [SUPPORT.md](SUPPORT.md) if you're stuck or have questions.
+
+## **Ways to Get Involved**
+
+Anyone is welcome to contribute and make this project better! You can:
+
+- Join our slack community [here](https://codebuddies.org/slack)
+- Share your feedback on [Github CBV3 frontend issues](https://github.com/codebuddies/frontend/issues)
+- Help review [CBV3 frontend pull requests](https://github.com/codebuddies/frontend/pulls) with comments!
+
+## **CODE OF CONDUCT.md**
+
+_Please_ read CodeBuddies' [Code of Conduct](CODE_OF_CONDUCT.md) to understand the responsibility and scope as a contributor at CodeBuddies.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+## **Ways to get help**
+
+1. Join [our Slack community](https://codebuddies.org) and ask for help in #codebuddies-meta, #cb-v3-frontend, or #reactjs channels
+
+2. [File a new issue](https://github.com/codebuddies/frontend/issues/new/choose) or comment on an existing issue with your question!


### PR DESCRIPTION
## Context
Thought this repo could use some re-org of the README and contribution instructions.

I tried to follow tips from https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file, but this is a SUPER quick draft that I rushed a little on since it was getting late. Feedback/comments welcome!

## Implementation
[x] new contributing.md file
[x] new support.md file
[x] new code_of_conduct.md file
[x] rewrote README.md (feedback welcome, since this was quick)